### PR TITLE
Add voice API endpoint for glucose readings

### DIFF
--- a/lib/api/voice.js
+++ b/lib/api/voice.js
@@ -42,7 +42,7 @@ function mostRecentSgv (sgvs) {
 function create (env, ctx) {
   var voice = express();
 
-  voice.get(['/', '/*'], function getVoice (req, res) {
+  voice.get(['/', '/*'], ctx.authorization.isPermitted('api:entries:read'), function getVoice (req, res) {
     var sbx = sandbox.serverInit(env, ctx);
     ctx.plugins.setProperties(sbx);
 

--- a/lib/api/voice.js
+++ b/lib/api/voice.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var express = require('express');
+var sandbox = require('../sandbox')();
+
+var DIRECTION_TO_TREND = {
+  DoubleUp: 'rising rapidly'
+  , SingleUp: 'rising'
+  , FortyFiveUp: 'rising slowly'
+  , Flat: 'steady'
+  , FortyFiveDown: 'falling slowly'
+  , SingleDown: 'falling'
+  , DoubleDown: 'falling rapidly'
+};
+
+function formatRelativeTime (mills, now) {
+  var seconds = Math.max(0, Math.round((now - mills) / 1000));
+  if (seconds < 60) return 'just now';
+  var minutes = Math.round(seconds / 60);
+  if (minutes === 1) return '1 minute ago';
+  if (minutes < 60) return minutes + ' minutes ago';
+  var hours = Math.round(minutes / 60);
+  if (hours === 1) return 'an hour ago';
+  if (hours < 24) return hours + ' hours ago';
+  return 'over a day ago';
+}
+
+function buildSpeech (mmol, trend, relTime) {
+  var speech = 'Your glucose is ' + mmol;
+  if (trend) speech += ', ' + trend;
+  speech += ', as of ' + relTime + '.';
+  return speech;
+}
+
+function mostRecentSgv (sgvs) {
+  if (!sgvs || !sgvs.length) return null;
+  return sgvs.reduce(function (a, b) {
+    return (a && a.mills > b.mills) ? a : b;
+  }, null);
+}
+
+function create (env, ctx) {
+  var voice = express();
+
+  voice.get(['/', '/*'], function getVoice (req, res) {
+    var sbx = sandbox.serverInit(env, ctx);
+    ctx.plugins.setProperties(sbx);
+
+    var bgnow = sbx.properties && sbx.properties.bgnow;
+    var recentMgdl = bgnow && (bgnow.mean || bgnow.last);
+    var recentMills = bgnow && bgnow.mills;
+
+    if (!recentMgdl || !recentMills) {
+      var missingText = 'No recent glucose reading is available.';
+      if (req.query && req.query.format === 'json') {
+        res.json({ text: missingText });
+      } else {
+        res.type('text/plain').send(missingText);
+      }
+      return;
+    }
+
+    var mmolRaw = recentMgdl / 18;
+    var mmol = (Math.round(mmolRaw * 10) / 10).toFixed(1);
+
+    var sgv = mostRecentSgv(bgnow.sgvs);
+    var direction = sgv ? sgv.direction : null;
+    var trend = DIRECTION_TO_TREND[direction] || null;
+
+    var relTime = formatRelativeTime(recentMills, Date.now());
+    var text = buildSpeech(mmol, trend, relTime);
+
+    if (req.query && req.query.format === 'json') {
+      res.json({
+        text: text
+        , mgdl: Math.round(recentMgdl)
+        , mmol: Number(mmol)
+        , direction: direction
+        , trend: trend
+        , mills: recentMills
+      });
+      return;
+    }
+
+    res.type('text/plain').send(text);
+  });
+
+  return voice;
+}
+
+module.exports = create;

--- a/lib/server/app.js
+++ b/lib/server/app.js
@@ -187,6 +187,7 @@ function create (env, ctx) {
   var api3 = require('../api3/')(env, ctx);
   var ddata = require('../data/endpoints')(env, ctx);
   var notificationsV2 = require('../api/notifications-v2')(app, ctx);
+  var voice = require('../api/voice')(env, ctx);
 
   app.use(compression({
     filter: function shouldCompress (req, res) {
@@ -254,6 +255,7 @@ function create (env, ctx) {
   app.use('/api/v2/authorization', ctx.authorization.endpoints);
   app.use('/api/v2/ddata', ddata);
   app.use('/api/v2/notifications', notificationsV2);
+  app.use('/api/v2/voice', voice);
 
   app.use('/api/v3', api3);
 


### PR DESCRIPTION
## Summary
This PR adds a new voice API endpoint that provides glucose readings in a human-readable speech format, suitable for voice assistants and accessibility features.

## Key Changes
- **New voice API module** (`lib/api/voice.js`): Implements a new endpoint that converts glucose data into natural language speech
  - Converts blood glucose from mg/dL to mmol/L
  - Maps glucose trend directions to human-readable descriptions (e.g., "rising rapidly", "falling slowly")
  - Formats timestamps as relative time (e.g., "5 minutes ago")
  - Supports both plain text and JSON response formats via `?format=json` query parameter
  - Includes proper authorization checks using the existing `api:entries:read` permission
  
- **Route registration** (`lib/server/app.js`): Registers the new voice endpoint at `/api/v2/voice`

## Notable Implementation Details
- The endpoint returns a complete speech sentence by default: "Your glucose is X.X mmol, [trend], as of [time]."
- JSON responses include additional structured data: mg/dL value, mmol value, direction code, trend text, and timestamp
- Gracefully handles missing glucose data with an appropriate message
- Uses the sandbox pattern for consistent data access and plugin initialization
- Trend mapping supports all standard CGM direction indicators (DoubleUp, SingleUp, FortyFiveUp, Flat, FortyFiveDown, SingleDown, DoubleDown)

https://claude.ai/code/session_01MpBNdjdWnefnZLtVwkfqrw